### PR TITLE
ci: setup base workflows for Testing + Releases

### DIFF
--- a/.github/workflows/manual-bump-version.yml
+++ b/.github/workflows/manual-bump-version.yml
@@ -1,0 +1,31 @@
+name: .bump-version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_VERSION_BUMP_PAT }}
+
+      - name: Configure git user
+        run: |
+          git config --local user.email "accounts+github-ci-bot@datapane.com"
+          git config --local user.name "datapane-ci-bot"
+
+      - uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install 'poetry~=1.4.0'
+          poetry install
+
+      - name: Bump version
+        run:
+          poetry run poe git-bump-version
+          git push --tags

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,0 +1,10 @@
+name: PR
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: ./.github/workflows/wf-test.yml

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -8,3 +8,8 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/wf-test.yml
+
+  release:
+    uses: ./.github/workflows/wf-release.yml
+    with:
+      release-pypi: false

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,4 +1,4 @@
-name: PR
+name: On Merge
 
 on:
   push:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -9,6 +9,9 @@ jobs:
   test:
     uses: ./.github/workflows/wf-test.yml
 
+  lint:
+    uses: ./.github/workflows/wf-lint.yml
+
   release:
     uses: ./.github/workflows/wf-release.yml
     with:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -8,3 +8,7 @@ jobs:
   test:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/wf-test.yml
+
+  lint:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/wf-lint.yml

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,0 +1,10 @@
+name: PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/wf-test.yml

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,3 +11,7 @@ jobs:
 
   release:
     uses: ./.github/workflows/wf-release.yml
+    with:
+      release-pypi: true
+    secrets:
+      POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,4 +1,4 @@
-name: PR
+name: On Release
 
 on:
   push:
@@ -8,3 +8,6 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/wf-test.yml
+
+  release:
+    uses: ./.github/workflows/wf-release.yml

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,10 @@
+name: PR
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    uses: ./.github/workflows/wf-test.yml

--- a/.github/workflows/wf-lint.yml
+++ b/.github/workflows/wf-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/wf-lint.yml
+++ b/.github/workflows/wf-lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    # TODO: all platforms
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install 'poetry~=1.4.0'
+          poetry install
+
+      - name: Lint
+        run: |
+          poetry run poe lint

--- a/.github/workflows/wf-release.yml
+++ b/.github/workflows/wf-release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_call:
+    inputs:
+      release-pypi:
+        description: 'Release to PyPI?'
+        default: false
+        type: boolean
+    secrets:
+      POETRY_PYPI_TOKEN_PYPI:
+        description: 'PyPI token'
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install 'poetry~=1.4.0'
+
+      - name: Build
+        run: poetry build -vv
+
+      - name: Publish GH Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dp-components
+          path: dist/*.whl
+
+      - name: Publish PyPI
+        if: ${{ inputs.release-pypi == true }}
+        run: poetry publish -vv
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}

--- a/.github/workflows/wf-release.yml
+++ b/.github/workflows/wf-release.yml
@@ -20,7 +20,7 @@ jobs:
   main:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/wf-test.yml
+++ b/.github/workflows/wf-test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  workflow_call:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  main:
+    # TODO: all platforms
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install 'poetry~=1.4.0'
+          poetry install
+
+      - name: Test
+        run: |
+          poetry run pytest

--- a/.github/workflows/wf-test.yml
+++ b/.github/workflows/wf-test.yml
@@ -10,6 +10,7 @@ defaults:
 jobs:
   main:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-22.04, macos-12, windows-2022]

--- a/.github/workflows/wf-test.yml
+++ b/.github/workflows/wf-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/wf-test.yml
+++ b/.github/workflows/wf-test.yml
@@ -9,14 +9,17 @@ defaults:
 
 jobs:
   main:
-    # TODO: all platforms
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+        os: [ubuntu-22.04, macos-12, windows-2022]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip install 'poetry~=1.4.0'

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -13,9 +13,20 @@ def _get_new_version():
     return f"{today.year}.{today.month}.{today.day}"
 
 
-def main():
+def _commit_and_tag(new_version: str):
+    prefixed_version = f"v{new_version}"
+
+    sh.git.add("pyproject.toml")
+    sh.git.commit("-m", f"Release {prefixed_version}")
+    sh.git.tag("-a", f"{prefixed_version}", "-m", f"Release {prefixed_version}")
+
+
+def main(git: bool = False):
     new_version = _get_new_version()
     sh.poetry.version("-vv", "--", new_version, _fg=True)
+
+    if git:
+        _commit_and_tag(new_version)
 
 
 if __name__ == "__main__":

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from datetime import date
+import sh
+
+
+def _get_new_version():
+    """We're utilising calver
+
+    returns string of form: YYYY.MM.DD
+    Does not include leading zeros
+    """
+    today = date.today()
+    return f'{today.year}.{today.month}.{today.day}'
+
+
+def main():
+    new_version = _get_new_version()
+    sh.poetry.version("-vv", "--", new_version, _fg=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -10,7 +10,7 @@ def _get_new_version():
     Does not include leading zeros
     """
     today = date.today()
-    return f'{today.year}.{today.month}.{today.day}'
+    return f"{today.year}.{today.month}.{today.day}"
 
 
 def main():
@@ -18,5 +18,5 @@ def main():
     sh.poetry.version("-vv", "--", new_version, _fg=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -16,9 +16,9 @@ def _get_new_version():
 def _commit_and_tag(new_version: str):
     prefixed_version = f"v{new_version}"
 
-    sh.git.add("pyproject.toml")
-    sh.git.commit("-m", f"Release {prefixed_version}")
-    sh.git.tag("-a", f"{prefixed_version}", "-m", f"Release {prefixed_version}")
+    sh.git.add("pyproject.toml", _fg=True)
+    sh.git.commit("-m", f"Release {prefixed_version}", _fg=True)
+    sh.git.tag("-a", f"{prefixed_version}", "-m", f"Release {prefixed_version}", _fg=True)
 
 
 def main(git: bool = False):

--- a/poetry.lock
+++ b/poetry.lock
@@ -385,6 +385,56 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "black"
+version = "23.1.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26"},
+    {file = "black-23.1.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b"},
+    {file = "black-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104"},
+    {file = "black-23.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:9afd3f493666a0cd8f8df9a0200c6359ac53940cbde049dcb1a7eb6ee2dd7074"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648"},
+    {file = "black-23.1.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958"},
+    {file = "black-23.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a"},
+    {file = "black-23.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:121ca7f10b4a01fd99951234abdbd97728e1240be89fde18480ffac16503d481"},
+    {file = "black-23.1.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad"},
+    {file = "black-23.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8"},
+    {file = "black-23.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a436e7881d33acaf2536c46a454bb964a50eff59b21b51c6ccf5a40601fbef24"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd"},
+    {file = "black-23.1.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580"},
+    {file = "black-23.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468"},
+    {file = "black-23.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b70eb40a78dfac24842458476135f9b99ab952dd3f2dab738c1881a9b38b753"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06"},
+    {file = "black-23.1.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739"},
+    {file = "black-23.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9"},
+    {file = "black-23.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0680d4380db3719ebcfb2613f34e86c8e6d15ffeabcf8ec59355c5e7b85bb555"},
+    {file = "black-23.1.0-py3-none-any.whl", hash = "sha256:7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32"},
+    {file = "black-23.1.0.tar.gz", hash = "sha256:b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "bleach"
 version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -2055,6 +2105,18 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "nbclassic"
 version = "0.5.3"
 description = "Jupyter Notebook as a Jupyter Server extension."
@@ -2414,6 +2476,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
     {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.11.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
 ]
 
 [[package]]
@@ -3128,6 +3202,33 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.0.256"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.256-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:eb8e949f6e7fb16f9aa163fcc13318e2b7910577513468417e5b003b984410a1"},
+    {file = "ruff-0.0.256-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:48a42f0ec4c5a3c3b062e947b2a5f8f7a4264761653fb0ee656a9b535ae6d8d7"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36ca633cfc335869643a13e2006f13a63bc4cb94073aa9508ceb08a1e3afe3af"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:80fa5d3a40dd0b65c6d6adea4f825984d5d3a215a25d90cc6139978cb22ea1cd"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0f88839b886db3577136375865bd080b9ed6f9b85bb990d897780e5a30ca3c2"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:fe6d77a43b2d52f45ee42f6f682198ed1c34cd0165812e276648981dfd50ad36"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3878593507b281b2615702ece06426e8b27076e8fedf658bf0c5e1e5e2ad1b40"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e052ec4d5c92663caa662b68fe1902ec10eddac2783229b1c5f20f3df62a865"},
+    {file = "ruff-0.0.256-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2116bd67e52ade9f90e5a3a3aa511a9b179c699690221bdd5bb267dbf7e94b22"},
+    {file = "ruff-0.0.256-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3c6e93d7818a75669328e49a0f7070c40e18676ca8e56ca9c566633bef4d8d05"},
+    {file = "ruff-0.0.256-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ebb7de4e62d751b65bb15418a83ac5d555afb3eaa3ad549dea21744da34ae86"},
+    {file = "ruff-0.0.256-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f310bfc76c0404a487759c8904f57bf51653c46e686c800efc1ff1d165a59a04"},
+    {file = "ruff-0.0.256-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:93a0cfec812b2ba57bff22b176901e0ddf44e4d42a9bd7da7ffb5e53df13fd6e"},
+    {file = "ruff-0.0.256-py3-none-win32.whl", hash = "sha256:d63e5320bc2d91e94925cd1863e381a48edf087041035967faf2614bb36a6a0d"},
+    {file = "ruff-0.0.256-py3-none-win_amd64.whl", hash = "sha256:859c8ffb1801895fe043a2b85a45cd0ff35667ddea4b465ba2a29d275550814a"},
+    {file = "ruff-0.0.256-py3-none-win_arm64.whl", hash = "sha256:64b276149e86c3d234608d3fe1da77535865e03debd3a1d5d04576f7f5031bbb"},
+    {file = "ruff-0.0.256.tar.gz", hash = "sha256:f9a96b34a4870ee8cf2f3779cd7854620d1788a83b52374771266cf800541bb7"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.0"
 description = "Send file to trash natively under Mac OS X, Windows and Linux."
@@ -3663,4 +3764,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8.0, < 3.12.0"
-content-hash = "3320fed954f5d8cb3198c69b73db9479b56e55f793762ee1fae3f5edfe01ba2f"
+content-hash = "514959315f6a0f272dab1cada6c98be4a260f5ec4fe6f172a5b0a5ccac236b59"

--- a/poetry.lock
+++ b/poetry.lock
@@ -817,7 +817,6 @@ files = [
     {file = "debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c"},
     {file = "debugpy-1.6.6-cp38-cp38-win32.whl", hash = "sha256:70ab53918fd907a3ade01909b3ed783287ede362c80c75f41e79596d5ccacd32"},
     {file = "debugpy-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:c05349890804d846eca32ce0623ab66c06f8800db881af7a876dc073ac1c2225"},
-    {file = "debugpy-1.6.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:11a0f3a106f69901e4a9a5683ce943a7a5605696024134b522aa1bfda25b5fec"},
     {file = "debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6"},
     {file = "debugpy-1.6.6-cp39-cp39-win32.whl", hash = "sha256:549ae0cb2d34fc09d1675f9b01942499751d174381b6082279cf19cdb3c47cbe"},
     {file = "debugpy-1.6.6-cp39-cp39-win_amd64.whl", hash = "sha256:de4a045fbf388e120bb6ec66501458d3134f4729faed26ff95de52a754abddb1"},
@@ -1767,7 +1766,6 @@ files = [
     {file = "lxml-4.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b9cc34af337a97d470040f99ba4282f6e6bac88407d021688a5d585e44a23184"},
     {file = "lxml-4.9.2-cp310-cp310-win32.whl", hash = "sha256:d02a5399126a53492415d4906ab0ad0375a5456cc05c3fc0fc4ca11771745cda"},
     {file = "lxml-4.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:a38486985ca49cfa574a507e7a2215c0c780fd1778bb6290c21193b7211702ab"},
-    {file = "lxml-4.9.2-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:6943826a0374fb135bb11843594eda9ae150fba9d1d027d2464c713da7c09afe"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c83203addf554215463b59f6399835201999b5e48019dc17f182ed5ad87205c9"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:2a87fa548561d2f4643c99cd13131acb607ddabb70682dcf1dff5f71f781a4bf"},
     {file = "lxml-4.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:d6b430a9938a5a5d85fc107d852262ddcd48602c120e3dbb02137c83d212b380"},
@@ -1778,6 +1776,7 @@ files = [
     {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ca989b91cf3a3ba28930a9fc1e9aeafc2a395448641df1f387a2d394638943b0"},
     {file = "lxml-4.9.2-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:822068f85e12a6e292803e112ab876bc03ed1f03dddb80154c395f891ca6b31e"},
     {file = "lxml-4.9.2-cp35-cp35m-win32.whl", hash = "sha256:be7292c55101e22f2a3d4d8913944cbea71eea90792bf914add27454a13905df"},
+    {file = "lxml-4.9.2-cp35-cp35m-win_amd64.whl", hash = "sha256:998c7c41910666d2976928c38ea96a70d1aa43be6fe502f21a651e17483a43c5"},
     {file = "lxml-4.9.2-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:b26a29f0b7fc6f0897f043ca366142d2b609dc60756ee6e4e90b5f762c6adc53"},
     {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:ab323679b8b3030000f2be63e22cdeea5b47ee0abd2d6a1dc0c8103ddaa56cd7"},
     {file = "lxml-4.9.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:689bb688a1db722485e4610a503e3e9210dcc20c520b45ac8f7533c837be76fe"},
@@ -1787,6 +1786,7 @@ files = [
     {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:58bfa3aa19ca4c0f28c5dde0ff56c520fbac6f0daf4fac66ed4c8d2fb7f22e74"},
     {file = "lxml-4.9.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:bc718cd47b765e790eecb74d044cc8d37d58562f6c314ee9484df26276d36a38"},
     {file = "lxml-4.9.2-cp36-cp36m-win32.whl", hash = "sha256:d5bf6545cd27aaa8a13033ce56354ed9e25ab0e4ac3b5392b763d8d04b08e0c5"},
+    {file = "lxml-4.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3ab9fa9d6dc2a7f29d7affdf3edebf6ece6fb28a6d80b14c3b2fb9d39b9322c3"},
     {file = "lxml-4.9.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:05ca3f6abf5cf78fe053da9b1166e062ade3fa5d4f92b4ed688127ea7d7b1d03"},
     {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:a5da296eb617d18e497bcf0a5c528f5d3b18dadb3619fbdadf4ed2356ef8d941"},
     {file = "lxml-4.9.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:04876580c050a8c5341d706dd464ff04fd597095cc8c023252566a8826505726"},
@@ -2405,6 +2405,18 @@ qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
+name = "pastel"
+version = "0.2.1"
+description = "Bring colors to your terminal."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
+    {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+
+[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -2474,6 +2486,25 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "poethepoet"
+version = "0.18.1"
+description = "A task runner that works well with poetry."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "poethepoet-0.18.1-py3-none-any.whl", hash = "sha256:e85727bf6f4a10bf6c1a43026bdeb40df689bea3c4682d03cbe531cabc8f2ba6"},
+    {file = "poethepoet-0.18.1.tar.gz", hash = "sha256:5f3566b14c2f5dccdfbc3bb26f0096006b38dc0b9c74bd4f8dd1eba7b0e29f6a"},
+]
+
+[package.dependencies]
+pastel = ">=0.2.1,<0.3.0"
+tomli = ">=1.2.2"
+
+[package.extras]
+poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
 name = "pooch"
@@ -3114,6 +3145,17 @@ objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
+name = "sh"
+version = "1.14.3"
+description = "Python subprocess replacement"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sh-1.14.3.tar.gz", hash = "sha256:e4045b6c732d9ce75d571c79f5ac2234edd9ae4f5fa9d59b09705082bdca18c7"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3621,4 +3663,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.8.0, < 3.12.0"
-content-hash = "00968b20ae25a6c50259e578b093c72badd7fd1ea2177782d7f3c99a1df2fae8"
+content-hash = "3320fed954f5d8cb3198c69b73db9479b56e55f793762ee1fae3f5edfe01ba2f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datapane-components"
-version = "0.0.1"
+version = "2023.3.15"
 description = "Reusable Datapane components and sample reports and apps"
 authors = ["Datapane Team <dev@datapane.com>"]
 license = "Apache 2.0"
@@ -52,6 +52,10 @@ jupyterlab = "^3.6.1"
 pytest = "^7.0.0"
 pytest-datadir = "^1.3.1"
 # datapane = { path = "../datapane/python-client", develop = true }
+poethepoet = "^0.18.1"
+
+# sh pinned to an older version, due to poetry incorrectly trying to make a single lockfile.
+sh = "^1.14.3"
 
 
 [build-system]
@@ -75,3 +79,6 @@ ignore = ["E501"]
 
 line-length = 120
 target-version = "py310"
+
+[tool.poe.tasks]
+bump-version = { "script" = "ci.bump_version:main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datapane-components"
-version = "2023.3.15"
+version = "2023.3.14"
 description = "Reusable Datapane components and sample reports and apps"
 authors = ["Datapane Team <dev@datapane.com>"]
 license = "Apache 2.0"
@@ -83,6 +83,7 @@ target-version = "py38"
 
 [tool.poe.tasks]
 bump-version = { "script" = "ci.bump_version:main" }
+git-bump-version = { "script" = "ci.bump_version:main(git=True)" }
 ruff-check = "ruff check . --diff"
 black-check = "black . --check --diff"
 ruff-fix = "ruff check . --fix --show-fixes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datapane-components"
-version = "2023.3.14"
+version = "2023.3.15"
 description = "Reusable Datapane components and sample reports and apps"
 authors = ["Datapane Team <dev@datapane.com>"]
 license = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ poethepoet = "^0.18.1"
 
 # sh pinned to an older version, due to poetry incorrectly trying to make a single lockfile.
 sh = "^1.14.3"
-
+black = "^23.1.0"
+ruff = "^0.0.256"
 
 [build-system]
 requires = ["poetry-core"]
@@ -64,7 +65,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py38']
 # include = '\.pyi?$'
 
 [tool.ruff]
@@ -78,7 +79,13 @@ ignore = ["E501"]
 #unfixable = []
 
 line-length = 120
-target-version = "py310"
+target-version = "py38"
 
 [tool.poe.tasks]
 bump-version = { "script" = "ci.bump_version:main" }
+ruff-check = "ruff check . --diff"
+black-check = "black . --check --diff"
+ruff-fix = "ruff check . --fix --show-fixes"
+black-fix = "black ."
+lint = { sequence = ["ruff-check", "black-check"] }
+fixlint = { sequence = ["ruff-fix", "black-fix"] }

--- a/src/datapane_components/utils.py
+++ b/src/datapane_components/utils.py
@@ -7,6 +7,7 @@ import datapane as dp
 print(dp.__version__)
 print(dp.__rev__)
 
+
 def divider() -> dp.Text:
     """
     Create a divider within your View
@@ -16,7 +17,7 @@ def divider() -> dp.Text:
     return dp.Text("---")
 
 
-def section(new_heading: str = "") -> t.List[dp.Block]:
+def section(new_heading: str = "") -> t.List[dp.Blocks]:
     """
     Create a Section dividier within your View
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,7 @@
 # Trivial tests to ensure basics working for now
-import typing as t
 
 import pytest
 import datapane as dp
-
-import datapane_components as dc
 
 
 def _check_view(v) -> None:
@@ -33,5 +30,3 @@ def test_datasets():
 
     with pytest.raises(AttributeError):
         df = datasets.load_dataset(dict(upload=None, dataset="airports1"))
-
-


### PR DESCRIPTION
- we test on each PR, on each merge to main, and on every release
  - These now run all supported platforms
- linting is also performed for PRs and Merges
- versioning adheres to calver convention: we just set the current date whenever bumping
- version bumping can be performed from GH Actions, same style as python-client

Actual releases still use poetry, aligned with python-client
As we're using Poetry, I've chucked `poe` in as a task runner (avoids needing to setup our other tooling, such as Task)